### PR TITLE
Issue 80, SQL script `000003_add_email_const.down.sql` was created.

### DIFF
--- a/pkg/ims/repository/postgresql/migrations/000003_add_email_const.down.sql
+++ b/pkg/ims/repository/postgresql/migrations/000003_add_email_const.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users 
+DROP CONSTRAINT email;
+
+COMMIT;


### PR DESCRIPTION
SQL script `000003_add_email_const.down.sql` drops unique constraint `email` in the `users` table.
Closes #80 